### PR TITLE
Fix: console cache:clear failing when annotations not enabled

### DIFF
--- a/doctrine/annotations/1.0/config/routes/annotations.yaml
+++ b/doctrine/annotations/1.0/config/routes/annotations.yaml
@@ -1,3 +1,3 @@
-controllers:
-    resource: ../src/Controller/
-    type: annotation
+#controllers:
+#    resource: ../src/Controller/
+#    type: annotation


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

When the console cache:clear command is launched without annotations enabled having this part uncommented (as it was [previously](https://github.com/symfony/recipes/commit/126f532c03756c3d5bc4e8881b6f3bea657a187c) in the symfony/routing recipe) cause the command to fail.

```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!   // Clearing the cache for the dev environment with debug                       
!!   // true                                                                        
!!  
!!  
!!                                                                                 
!!    [Symfony\Component\Config\Exception\FileLoaderLoadException]                 
!!    Cannot load resource "../src/Controller/". Make sure annotations are enable  
!!    d.                                                                           
!!                                                                                 
!!  
!!  cache:clear [--no-warmup] [--no-optional-warmers] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command>
!!  
!!  

```

This PR should fixe this. (I don't know how to test with a different recipe repo).